### PR TITLE
Update prompt evaluator notebook to include prod only example

### DIFF
--- a/notebooks/python_sdk/prompt_evaluator/rag/End to End Prompt Template Evaluation.ipynb
+++ b/notebooks/python_sdk/prompt_evaluator/rag/End to End Prompt Template Evaluation.ipynb
@@ -900,11 +900,11 @@
    "id": "a25db6b6",
    "metadata": {},
    "source": [
-    "### Set up and Evaluate Development Environment Only\n",
+    "### Set up and Evaluate The Prompt Template In Development Environment Only\n",
     "\n",
-    "The production space details can be removed from the configuration object to do the end to end set up and evaluation for development project.\n",
+    "The production project details can be excluded from the configuration object to perform a complete end-to-end setup and evaluation of the prompt template in development environment only.\n",
     "\n",
-    "Uncomment the next cell to only set up the prompt template and run the evaluation in the development project"
+    "Uncomment the next cell to set up the prompt template and run evaluation in the development environment only."
    ]
   },
   {
@@ -929,6 +929,44 @@
     "\n",
     "# evaluator.e2e_prompt_evaluation(\n",
     "#     config=development_only_config,\n",
+    "#     input_file_path=input_file_path,\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "856791f9",
+   "metadata": {},
+   "source": [
+    "### Set up and Evaluate The Prompt Template In Production Environment Only\n",
+    "\n",
+    "The development project details can be excluded from the configuration object to perform a complete end-to-end setup and evaluation of the prompt template in production environment only.\n",
+    "\n",
+    "Uncomment the next cell to set up the prompt template and run evaluation in the production environment only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "026c11c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# production_only_config = {\n",
+    "#     \"prompt_setup\": {\n",
+    "#         \"problem_type\": TaskType.RAG.value,\n",
+    "#         \"context_fields\": context_fields,\n",
+    "#     },\n",
+    "#     \"production_space_id\": SPACE_ID,\n",
+    "#     \"detached_prompt_template\": {\n",
+    "#         \"input_text\": prompt_input,\n",
+    "#         \"input_variables\": [question_field] + context_fields,\n",
+    "#         \"task_ids\": [TaskType.RAG.value],\n",
+    "#     },\n",
+    "# }\n",
+    "\n",
+    "# evaluator.e2e_prompt_evaluation(\n",
+    "#     config=production_only_config,\n",
     "#     input_file_path=input_file_path,\n",
     "# )"
    ]


### PR DESCRIPTION
This PR updates the Prompt Evaluator notebook to include an example on how to do the setup for production only.